### PR TITLE
Update scanner

### DIFF
--- a/scanForLog4jVulnerability.py
+++ b/scanForLog4jVulnerability.py
@@ -67,7 +67,7 @@ def setupParser():
     parser.add_argument("-t", "--timeout",
                     dest="timeout",
                     help="Request timeout period.",
-                    default="3",
+                    default="10",
                     action='store')
     parser.add_argument("-k", "--ignoressl",
                     dest="verifySsl",


### PR DESCRIPTION
Resource discovery takes a variable amount of time. The default of 3 seconds fails in at least one client context. Changing the default to 10. More data required to estimate the average return interval.